### PR TITLE
Troubleshooting Frontend Login and Main Page Routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,10 +50,11 @@ import ScrollToTop from "./utils/ScrollToTop.js";
 import FlexibleNotification from "./component/layout/MUI-comp/MuiNotification/FlexibleNotification.js";
 import Loader from "./component/layout/Loader/Loader.js";
 import NoAuthHeader from "./component/layout/Header/NoAuthHeader.js";
+
 function App() {
   //test
   const { isAuthenticated, user, loading } = useSelector((state) => state.user);
-  const [userLoaded, setUserLoaded] = useState(false);
+  const [initialized, setInitialized] = useState(false);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -71,9 +72,24 @@ function App() {
       },
     });
   }, []);
-useEffect(() => {
-  dispatch(loadUser()).then(() => setUserLoaded(true));
-}, [dispatch]);
+ // Silent auth check on app load
+ useEffect(() => {
+  const initAuth = async () => {
+    if (localStorage.getItem('accessToken')) {
+      try {
+        await dispatch(loadUser());
+      } catch (error) {
+        console.log("Failed to load user:", error);
+      }
+    }
+    setInitialized(true);
+  };
+
+  if (!initialized) {
+    initAuth();
+  }
+}, [dispatch, initialized]);
+
 if(loading){
 return <Loader/>
 }
@@ -93,7 +109,7 @@ return <Loader/>
         <Route>
           <>
 
-              <Header isAuthenticated={isAuthenticated} loading={loading} />   
+              <Header isAuthenticated={isAuthenticated} user={user}/>   
       
            
 
@@ -105,45 +121,33 @@ return <Loader/>
       )} */}
 
             <Switch>
-              <Route exact path="/" component={Home} />
-              <Route exact path="/product/:id" component={ProductDetails} />
-              <Route exact path="/products" component={Products} />
-              <Route path="/products/:keyword" component={Products} />
+            {/* Public Routes */}
+        <Route exact path="/" component={Home} />
+        <Route exact path="/products" component={Products} />
+        <Route exact path="/product/:id" component={ProductDetails} />
+        <Route exact path="/search" component={Search} />
+        <Route exact path="/contact" component={Contact} />
+        <Route exact path="/about" component={About} />
+        
+        {/* Auth Routes */}
+        <Route 
+          exact 
+          path="/login" 
+          render={(props) => 
+            isAuthenticated ? <Redirect to="/" /> : <LoginSignUp {...props} />
+          }
+        />
 
-              <Route exact path="/search" component={Search} />
-
-              <Route exact path="/contact" component={Contact} />
-
-              <Route exact path="/about" component={About} />
-              <Route exact path="/login" component={LoginSignUp} />
-
-              <ProtectedRoute exact path="/cart" component={Cart} />
-
-              <ProtectedRoute exact path="/account" component={Profile} />
-
-              <ProtectedRoute
-                exact
-                path="/member/update"
-                component={UpdateProfile}
-              />
-              <ProtectedRoute exact path="/shipping" component={Shipping} />
-
-              <ProtectedRoute exact path="/success" component={OrderSuccess} />
-
-              <ProtectedRoute exact path="/orders" component={MyOrders} />
-
-              <ProtectedRoute
-                exact
-                path="/order/confirm"
-                component={ConfirmOrder}
-              />
-
-              <ProtectedRoute
-                exact
-                path="/order/:id"
-                component={OrderDetails}
-              />
-
+        {/* Protected Routes */}
+        <ProtectedRoute exact path="/cart" component={Cart} />
+        <ProtectedRoute exact path="/account" component={Profile} />
+        <ProtectedRoute exact path="/member/update" component={UpdateProfile} />
+        <ProtectedRoute exact path="/shipping" component={Shipping} />
+        <ProtectedRoute exact path="/success" component={OrderSuccess} />
+        <ProtectedRoute exact path="/orders" component={MyOrders} />
+        <ProtectedRoute exact path="/order/confirm" component={ConfirmOrder} />
+        <ProtectedRoute exact path="/order/:id" component={OrderDetails} />
+        <Route component={NotFound} />
               {/* <ProtectedRoute
           exact
           path="/password/update"

--- a/src/utils/axiosInstance.js
+++ b/src/utils/axiosInstance.js
@@ -17,6 +17,14 @@ const axiosInstance = axios.create({
 let isRefreshing = false;
 let failedQueue = [];
 
+// Add a flag to identify public routes
+const isPublicRoute = (url) => {
+  return url.includes('/api/public/') || 
+         url.includes('/v1/login') || 
+         url.includes('/v1/register');
+};
+
+
 const processQueue = (error, token = null) => {
   failedQueue.forEach((prom) => {
     if (error) {
@@ -36,10 +44,12 @@ const logout = () => {
 };
 axiosInstance.interceptors.request.use(
   (config) => {
-    console.log("Axios instance baseURL:", axiosInstance.defaults.baseURL);
-    const accessToken = getAccessTokenFromStorage();
-    if (accessToken) {
-      config.headers["Authorization"] = `Bearer ${accessToken}`;
+    // Only add token for non-public routes
+    if (!isPublicRoute(config.url)) {
+      const accessToken = getAccessTokenFromStorage();
+      if (accessToken) {
+        config.headers["Authorization"] = `Bearer ${accessToken}`;
+      }
     }
     return config;
   },
@@ -62,7 +72,9 @@ axiosInstance.interceptors.response.use(
         return Promise.reject(error);
       }
       // Handle 401 Unauthorized errors
-      if (error.response.status === 401 && !originalRequest._retry) {
+      if (!isPublicRoute(originalRequest.url) && 
+      error.response?.status === 401 && 
+      !originalRequest._retry) {
         console.log("refresh token call");
         if (isRefreshing) {
           return new Promise((resolve, reject) => {
@@ -91,9 +103,13 @@ axiosInstance.interceptors.response.use(
         return axiosInstance(originalRequest);
       } catch (refreshError) {
         processQueue(refreshError, null);
-      // Always logout on refresh failure
-        logout();
-
+   
+      if (!isPublicRoute(originalRequest.url)) {
+        store.dispatch(showNotification("Session expired. Please log in again.", "error"));
+        removeAccessTokenFromStorage();
+        history.push('/login');
+      }
+      logout();
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;


### PR DESCRIPTION
Allow public routes to work without requiring authentication Still maintain auth state when it exists
Only attempt refresh token for protected routes
Keep header state consistent
Allow users to see public pages even when not logged in